### PR TITLE
Bump version bounds

### DIFF
--- a/src/Text/Password/Strength/Internal/Adjacency.hs
+++ b/src/Text/Password/Strength/Internal/Adjacency.hs
@@ -165,7 +165,7 @@ scoreSequence s a =
     -- both characters.
     layers :: AdjacencyScore -> AdjacencyScore
     layers = if (s ^. patternLength) == 0
-               then layer (a ^. firstLayer) . (& layer (a ^. secondLayer))
+               then layer (a ^. firstLayer) . layer (a ^. secondLayer)
                else layer (a ^. secondLayer)
 
     layer :: Layer -> AdjacencyScore -> AdjacencyScore

--- a/zxcvbn-hs.cabal
+++ b/zxcvbn-hs.cabal
@@ -45,14 +45,14 @@ common options
 common dependencies
   build-depends:
     , aeson                 >=1.3  && <1.6
-    , attoparsec            ^>=0.13
+    , attoparsec            >=0.13 && <0.15
     , base                  >=4.9  && <5.0
     , base64-bytestring     >=1.0  && <1.3
     , binary                >=0.8  && <0.11
-    , binary-instances      ^>=1
+    , binary-instances      >=1 && <2.0
     , containers            ^>=0.6
     , fgl                   ^>=5.7
-    , lens                  >=4.17 && <5
+    , lens                  >=4.17 && <6
     , math-functions        ^>=0.3
     , text                  ^>=1.2
     , time                  >=1.8  && <2.0
@@ -132,7 +132,7 @@ test-suite test
   build-depends:
     , hedgehog        >=0.6  && <1.1
     , tasty           >=1.1  && <1.5
-    , tasty-hedgehog  >=0.2  && <1.1
+    , tasty-hedgehog  >=0.2  && <2
     , tasty-hunit     ^>=0.10
     , zxcvbn-hs
 


### PR DESCRIPTION
This makes zxcvbn-hs build on the latest nixpkgs commit.
None of these version bounds appeared to cause issues.