### PR TITLE
Losen various upper bounds

### DIFF
--- a/zxcvbn-hs.cabal
+++ b/zxcvbn-hs.cabal
@@ -44,20 +44,20 @@ common options
 --------------------------------------------------------------------------------
 common dependencies
   build-depends:
-    , aeson                 >=1.3  && <2.1
+    , aeson                 >=1.3  && <2.2
     , attoparsec            >=0.13 && <0.15
     , base                  >=4.9  && <5.0
     , base64-bytestring     >=1.0  && <1.3
     , binary                >=0.8  && <0.11
     , binary-instances      >=1    && <2.0
     , containers            ^>=0.6
-    , fgl                   ^>=5.7
+    , fgl                   >=5.7  && <5.9
     , lens                  >=4.17 && <6
     , math-functions        ^>=0.3
     , text                  >=1.2  && <2.1
     , time                  >=1.8  && <2.0
     , unordered-containers  ^>=0.2
-    , vector                ^>=0.12
+    , vector                >=0.12 && <0.14
     , zlib                  ^>=0.6
 
 --------------------------------------------------------------------------------
@@ -65,7 +65,7 @@ common tool-dependencies
   build-depends:
     , filepath              ^>=1.4
     , mtl                   ^>=2.2
-    , optparse-applicative  >=0.14 && <0.16
+    , optparse-applicative  >=0.14 && <0.18
     , pipes                 ^>=4.3
     , pipes-safe            ^>=2.3
     , pipes-text            >=0.0  && <1.1
@@ -130,7 +130,7 @@ test-suite test
   hs-source-dirs: test
   main-is:        Main.hs
   build-depends:
-    , hedgehog        >=0.6  && <1.2
+    , hedgehog        >=0.6  && <1.3
     , tasty           >=1.1  && <1.5
     , tasty-hedgehog  >=0.2  && <2
     , tasty-hunit     ^>=0.10
@@ -153,5 +153,5 @@ benchmark bench
   main-is:          Main.hs
   ghc-prof-options: -rtsopts
   build-depends:
-    , criterion  ^>=1.5
+    , criterion  >=1.5 && <1.7
     , zxcvbn-hs


### PR DESCRIPTION
I'm doing this because I'm trying to add this library [to stackage](https://github.com/commercialhaskell/stackage/pull/7000/commits/4c25e1e5c29fef2676ac07e5d40a6acf0347885f), so that we can add yesod-auth-simple to stackage as well.

This will make it more visible on (eg available on hoogle), and I'd get notifications on build failures with new ghc or library versions.