### PR TITLE
Add automated version bumping of dependencies

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -1,0 +1,28 @@
+# https://github.com/nomeata/haskell-bounds-bump-action
+on:
+  # allows manual triggering from https://github.com/../../actions/workflows/bump.yml
+  workflow_dispatch:
+  # runs weekly on Thursday at 8:00
+  schedule:
+           # ┌────────────── minute (0 - 59)
+           # │ ┌────────────── hour (0 - 23)
+           # │ │  ┌───────────── day of the month (1 - 31)
+           # │ │  │ ┌───────────── month (1 - 12 or JAN-DEC)
+           # │ │  │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+           # │ │  │ │ │
+           # │ │  │ │ │
+           # │ │  │ │ │
+           # * *  * * *
+    - cron: '0 18 * * 4'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: nomeata/haskell-bounds-bump-action@main
+      with:
+        test: false


### PR DESCRIPTION
This will automatically create a PR if it detects an depedency is outdated.
We then can see the changelog and check CI to make sure all is in order to merge it.
This should remove a lot of the tedium bound bumping of maintaining packages.