### PR TITLE
Bumps, zlib 0.7 & hedgehog 1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Revision History
 
-## 0.3.6 2023.09.11 
+## 0.3.7 2026.01.21
++ Compatible with zlib-0.7, bump bounds
++ Allow hedgehog 1.5
+
+## 0.3.6 2023.09.11
 + bump tasty bounds
 
-## 0.3.4 2023.08.13 
+## 0.3.4 2023.08.13
 + Bump opt parse applicative [#20](https://github.com/sthenauth/zxcvbn-hs/pull/20)
 
 ## 0.3.3 (Aug 02 2023)

--- a/zxcvbn-hs.cabal
+++ b/zxcvbn-hs.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               zxcvbn-hs
-version:            0.3.6
+version:            0.3.7
 synopsis:           Password strength estimation based on zxcvbn.
 license:            MIT
 license-file:       LICENSE
@@ -58,7 +58,7 @@ common dependencies
     time >=1.8 && <2.0,
     unordered-containers ^>=0.2,
     vector >=0.12 && <0.14,
-    zlib ^>=0.6
+    zlib ^>=0.6 || ^>=0.7.0,
 
 --------------------------------------------------------------------------------
 library
@@ -127,7 +127,7 @@ test-suite test
   hs-source-dirs: test
   main-is:        Main.hs
   build-depends:
-    hedgehog >=0.6 && <1.3 || ^>=1.3 || ^>=1.4,
+    hedgehog >=0.6 && <1.6,
     tasty >=1.1 && <1.6,
     tasty-hedgehog >=0.2 && <2,
     tasty-hunit ^>=0.10,


### PR DESCRIPTION
Hey @jappeace, recreating #30 with my suggestions included.

Primarily, allows zlib 0.7 — see here https://hackage.haskell.org/package/zlib-0.7.1.1/changelog

As I posted last year in #30 — this compiles, passes tests, and even speed goes up in benchmarks :stonks:

Please merge & release. 🙏  I'll throw in a provisional changelog stanza & version bump too